### PR TITLE
Fix gettting ServerName for host with domain part

### DIFF
--- a/src/metrics/parseReport.go
+++ b/src/metrics/parseReport.go
@@ -18,8 +18,9 @@ func getterFactory(jsonString string) func(path string, a ...interface{}) gjson.
 }
 
 func getServerName(file os.FileInfo) string {
-	parts := strings.Split(file.Name(), ".")
-	serverName := parts[len(parts)-2]
+	filename := file.Name()
+	lastDot := strings.LastIndex(filename, ".")
+  	serverName := filename[0:lastDot]	
 	return serverName
 }
 


### PR DESCRIPTION
Fix getting ServerName for a hostname that contains the domain part. For example hostname "example.com".